### PR TITLE
Allow configuring the number of days to expire documents

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 # Environment variables for development
 RUST_LOG=info
+EXPIRY_DAYS=1

--- a/rustpad-server/src/lib.rs
+++ b/rustpad-server/src/lib.rs
@@ -51,6 +51,12 @@ pub struct ServerData {
     pub expiry_days: u32,
 }
 
+impl Default for ServerData {
+    fn default() -> Self {
+        Self { expiry_days: 1 }
+    }
+}
+
 /// A combined filter handling all server routes.
 pub fn server(data: ServerData) -> BoxedFilter<(impl Reply,)> {
     warp::path("api").and(backend(data)).or(frontend()).boxed()

--- a/rustpad-server/src/main.rs
+++ b/rustpad-server/src/main.rs
@@ -1,4 +1,4 @@
-use rustpad_server::server;
+use rustpad_server::{server, ServerData};
 
 #[tokio::main]
 async fn main() {
@@ -10,5 +10,12 @@ async fn main() {
         .parse()
         .expect("Unable to parse PORT");
 
-    warp::serve(server()).run(([0, 0, 0, 0], port)).await;
+    let data = ServerData {
+        expiry_days: std::env::var("EXPIRY_DAYS")
+            .unwrap_or_else(|_| String::from("1"))
+            .parse()
+            .expect("Unable to parse EXPIRY_DAYS"),
+    };
+
+    warp::serve(server(data)).run(([0, 0, 0, 0], port)).await;
 }

--- a/rustpad-server/src/main.rs
+++ b/rustpad-server/src/main.rs
@@ -1,4 +1,4 @@
-use rustpad_server::{server, ServerData};
+use rustpad_server::{server, ServerConfig};
 
 #[tokio::main]
 async fn main() {
@@ -10,12 +10,12 @@ async fn main() {
         .parse()
         .expect("Unable to parse PORT");
 
-    let data = ServerData {
+    let config = ServerConfig {
         expiry_days: std::env::var("EXPIRY_DAYS")
             .unwrap_or_else(|_| String::from("1"))
             .parse()
             .expect("Unable to parse EXPIRY_DAYS"),
     };
 
-    warp::serve(server(data)).run(([0, 0, 0, 0], port)).await;
+    warp::serve(server(config)).run(([0, 0, 0, 0], port)).await;
 }

--- a/rustpad-server/tests/cleanup.rs
+++ b/rustpad-server/tests/cleanup.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use anyhow::Result;
 use common::*;
 use operational_transform::OperationSeq;
-use rustpad_server::{server, ServerData};
+use rustpad_server::{server, ServerConfig};
 use serde_json::json;
 use tokio::time;
 
@@ -14,9 +14,9 @@ pub mod common;
 #[tokio::test]
 async fn test_cleanup() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server(ServerData {
+    let filter = server(ServerConfig {
         expiry_days: 2,
-        ..ServerData::default()
+        ..ServerConfig::default()
     });
 
     expect_text(&filter, "old", "").await;

--- a/rustpad-server/tests/cleanup.rs
+++ b/rustpad-server/tests/cleanup.rs
@@ -14,7 +14,10 @@ pub mod common;
 #[tokio::test]
 async fn test_cleanup() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server(ServerData::default());
+    let filter = server(ServerData {
+        expiry_days: 2,
+        ..ServerData::default()
+    });
 
     expect_text(&filter, "old", "").await;
 
@@ -39,7 +42,7 @@ async fn test_cleanup() -> Result<()> {
 
     let hour = Duration::from_secs(3600);
     time::pause();
-    time::advance(23 * hour).await;
+    time::advance(46 * hour).await;
     expect_text(&filter, "old", "hello").await;
 
     time::advance(3 * hour).await;

--- a/rustpad-server/tests/cleanup.rs
+++ b/rustpad-server/tests/cleanup.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use anyhow::Result;
 use common::*;
 use operational_transform::OperationSeq;
-use rustpad_server::server;
+use rustpad_server::{server, ServerData};
 use serde_json::json;
 use tokio::time;
 
@@ -14,7 +14,7 @@ pub mod common;
 #[tokio::test]
 async fn test_cleanup() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server();
+    let filter = server(ServerData::default());
 
     expect_text(&filter, "old", "").await;
 

--- a/rustpad-server/tests/cleanup.rs
+++ b/rustpad-server/tests/cleanup.rs
@@ -42,7 +42,7 @@ async fn test_cleanup() -> Result<()> {
 
     let hour = Duration::from_secs(3600);
     time::pause();
-    time::advance(46 * hour).await;
+    time::advance(47 * hour).await;
     expect_text(&filter, "old", "hello").await;
 
     time::advance(3 * hour).await;

--- a/rustpad-server/tests/sockets.rs
+++ b/rustpad-server/tests/sockets.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use common::*;
 use log::info;
 use operational_transform::OperationSeq;
-use rustpad_server::{server, ServerData};
+use rustpad_server::{server, ServerConfig};
 use serde_json::json;
 use tokio::time;
 
@@ -15,7 +15,7 @@ pub mod common;
 #[tokio::test]
 async fn test_single_operation() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server(ServerData::default());
+    let filter = server(ServerConfig::default());
 
     expect_text(&filter, "foobar", "").await;
 
@@ -54,7 +54,7 @@ async fn test_single_operation() -> Result<()> {
 #[tokio::test]
 async fn test_invalid_operation() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server(ServerData::default());
+    let filter = server(ServerConfig::default());
 
     expect_text(&filter, "foobar", "").await;
 
@@ -80,7 +80,7 @@ async fn test_invalid_operation() -> Result<()> {
 #[tokio::test]
 async fn test_concurrent_transform() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server(ServerData::default());
+    let filter = server(ServerConfig::default());
 
     // Connect the first client
     let mut client = connect(&filter, "foobar").await?;
@@ -199,7 +199,7 @@ async fn test_concurrent_transform() -> Result<()> {
 #[tokio::test]
 async fn test_set_language() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server(ServerData::default());
+    let filter = server(ServerConfig::default());
 
     let mut client = connect(&filter, "foobar").await?;
     let msg = client.recv().await?;

--- a/rustpad-server/tests/sockets.rs
+++ b/rustpad-server/tests/sockets.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use common::*;
 use log::info;
 use operational_transform::OperationSeq;
-use rustpad_server::server;
+use rustpad_server::{server, ServerData};
 use serde_json::json;
 use tokio::time;
 
@@ -15,7 +15,7 @@ pub mod common;
 #[tokio::test]
 async fn test_single_operation() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server();
+    let filter = server(ServerData::default());
 
     expect_text(&filter, "foobar", "").await;
 
@@ -54,7 +54,7 @@ async fn test_single_operation() -> Result<()> {
 #[tokio::test]
 async fn test_invalid_operation() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server();
+    let filter = server(ServerData::default());
 
     expect_text(&filter, "foobar", "").await;
 
@@ -80,7 +80,7 @@ async fn test_invalid_operation() -> Result<()> {
 #[tokio::test]
 async fn test_concurrent_transform() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server();
+    let filter = server(ServerData::default());
 
     // Connect the first client
     let mut client = connect(&filter, "foobar").await?;
@@ -199,7 +199,7 @@ async fn test_concurrent_transform() -> Result<()> {
 #[tokio::test]
 async fn test_set_language() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server();
+    let filter = server(ServerData::default());
 
     let mut client = connect(&filter, "foobar").await?;
     let msg = client.recv().await?;

--- a/rustpad-server/tests/stress.rs
+++ b/rustpad-server/tests/stress.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Result};
 use common::*;
 use log::info;
 use operational_transform::OperationSeq;
-use rustpad_server::{server, ServerData};
+use rustpad_server::{server, ServerConfig};
 use serde_json::{json, Value};
 use tokio::time::Instant;
 
@@ -15,7 +15,7 @@ pub mod common;
 #[tokio::test]
 async fn test_lost_wakeups() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server(ServerData::default());
+    let filter = server(ServerConfig::default());
 
     expect_text(&filter, "stress", "").await;
 
@@ -74,7 +74,7 @@ async fn test_lost_wakeups() -> Result<()> {
 #[tokio::test]
 async fn test_large_document() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server(ServerData::default());
+    let filter = server(ServerConfig::default());
 
     expect_text(&filter, "stress", "").await;
 

--- a/rustpad-server/tests/stress.rs
+++ b/rustpad-server/tests/stress.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Result};
 use common::*;
 use log::info;
 use operational_transform::OperationSeq;
-use rustpad_server::server;
+use rustpad_server::{server, ServerData};
 use serde_json::{json, Value};
 use tokio::time::Instant;
 
@@ -15,7 +15,7 @@ pub mod common;
 #[tokio::test]
 async fn test_lost_wakeups() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server();
+    let filter = server(ServerData::default());
 
     expect_text(&filter, "stress", "").await;
 
@@ -74,7 +74,7 @@ async fn test_lost_wakeups() -> Result<()> {
 #[tokio::test]
 async fn test_large_document() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server();
+    let filter = server(ServerData::default());
 
     expect_text(&filter, "stress", "").await;
 

--- a/rustpad-server/tests/users.rs
+++ b/rustpad-server/tests/users.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use common::*;
-use rustpad_server::{server, ServerData};
+use rustpad_server::{server, ServerConfig};
 use serde_json::json;
 
 pub mod common;
@@ -10,7 +10,7 @@ pub mod common;
 #[tokio::test]
 async fn test_two_users() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server(ServerData::default());
+    let filter = server(ServerConfig::default());
 
     let mut client = connect(&filter, "foobar").await?;
     assert_eq!(client.recv().await?, json!({ "Identity": 0 }));
@@ -54,7 +54,7 @@ async fn test_two_users() -> Result<()> {
 #[tokio::test]
 async fn test_invalid_user() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server(ServerData::default());
+    let filter = server(ServerConfig::default());
 
     let mut client = connect(&filter, "foobar").await?;
     assert_eq!(client.recv().await?, json!({ "Identity": 0 }));
@@ -69,7 +69,7 @@ async fn test_invalid_user() -> Result<()> {
 #[tokio::test]
 async fn test_leave_rejoin() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server(ServerData::default());
+    let filter = server(ServerConfig::default());
 
     let mut client = connect(&filter, "foobar").await?;
     assert_eq!(client.recv().await?, json!({ "Identity": 0 }));
@@ -114,7 +114,7 @@ async fn test_leave_rejoin() -> Result<()> {
 #[tokio::test]
 async fn test_cursors() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server(ServerData::default());
+    let filter = server(ServerConfig::default());
 
     let mut client = connect(&filter, "foobar").await?;
     assert_eq!(client.recv().await?, json!({ "Identity": 0 }));

--- a/rustpad-server/tests/users.rs
+++ b/rustpad-server/tests/users.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use common::*;
-use rustpad_server::server;
+use rustpad_server::{server, ServerData};
 use serde_json::json;
 
 pub mod common;
@@ -10,7 +10,7 @@ pub mod common;
 #[tokio::test]
 async fn test_two_users() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server();
+    let filter = server(ServerData::default());
 
     let mut client = connect(&filter, "foobar").await?;
     assert_eq!(client.recv().await?, json!({ "Identity": 0 }));
@@ -54,7 +54,7 @@ async fn test_two_users() -> Result<()> {
 #[tokio::test]
 async fn test_invalid_user() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server();
+    let filter = server(ServerData::default());
 
     let mut client = connect(&filter, "foobar").await?;
     assert_eq!(client.recv().await?, json!({ "Identity": 0 }));
@@ -69,7 +69,7 @@ async fn test_invalid_user() -> Result<()> {
 #[tokio::test]
 async fn test_leave_rejoin() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server();
+    let filter = server(ServerData::default());
 
     let mut client = connect(&filter, "foobar").await?;
     assert_eq!(client.recv().await?, json!({ "Identity": 0 }));
@@ -114,7 +114,7 @@ async fn test_leave_rejoin() -> Result<()> {
 #[tokio::test]
 async fn test_cursors() -> Result<()> {
     pretty_env_logger::try_init().ok();
-    let filter = server();
+    let filter = server(ServerData::default());
 
     let mut client = connect(&filter, "foobar").await?;
     assert_eq!(client.recv().await?, json!({ "Identity": 0 }));


### PR DESCRIPTION
See #7 

This PR makes it possible to change the number of days to expire documents via `.env`:

```
EXPIRY_DAYS=1
```
