### PR TITLE
Fix Docker build and add multi-platform support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
     name: Docker Build and Push
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM ekidd/rust-musl-builder:latest as backend
+FROM rust:alpine as backend
 WORKDIR /home/rust/src
+RUN apk --no-cache add musl-dev openssl-dev
 COPY . .
-RUN cargo test --release
-RUN cargo build --release
+RUN cargo test --release rustpad-server
+RUN cargo build --release rustpad-server
 
 FROM rust:alpine as wasm
 WORKDIR /home/rust/src
@@ -23,6 +24,6 @@ RUN npm run build
 
 FROM scratch
 COPY --from=frontend /usr/src/app/build build
-COPY --from=backend /home/rust/src/target/x86_64-unknown-linux-musl/release/rustpad-server .
+COPY --from=backend /home/rust/src/target/release/rustpad-server .
 USER 1000:1000
 CMD [ "./rustpad-server" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM rust:alpine as backend
 WORKDIR /home/rust/src
 RUN apk --no-cache add musl-dev openssl-dev
 COPY . .
-RUN cargo test --release rustpad-server
-RUN cargo build --release rustpad-server
+RUN cargo test --release
+RUN cargo build --release
 
 FROM rust:alpine as wasm
 WORKDIR /home/rust/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 COPY . .
 RUN wasm-pack build rustpad-wasm
 
-FROM node:alpine as frontend
+FROM node:lts-alpine as frontend
 WORKDIR /usr/src/app
 COPY package.json package-lock.json ./
 COPY --from=wasm /home/rust/src/rustpad-wasm/pkg rustpad-wasm/pkg

--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ docker pull ekzhang/rustpad
 ```
 
 (You can also manually build this image with `docker build -t rustpad .` in the
-project root directory.) To run locally, execute the following command, then
-open `http://localhost:3030` in your browser.
+project root directory, ensuring that your target platform is `linux/amd64`.) To
+run locally, execute the following command, then open `http://localhost:3030` in
+your browser.
 
 ```
 docker run --rm -dp 3030:3030 ekzhang/rustpad

--- a/rustpad-server/Cargo.toml
+++ b/rustpad-server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustpad-server"
 version = "0.1.0"
 authors = ["Eric Zhang <ekzhang1@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0.40"

--- a/rustpad-wasm/Cargo.toml
+++ b/rustpad-wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustpad-wasm"
 version = "0.1.0"
 authors = ["Eric Zhang <ekzhang1@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
There was a build error in the last commit, because `node:alpine` updated to Node v17, but some packages in the NPM ecosystem that we rely on only support Node <= v16. To remedy this issue, the Dockerfile has been changed to use the `node:lts-alpine` tag instead, which has a more stable LTS version.

~~(I'm also going to update the build to be multi-platform, so new versions of the Docker image will support all three of `linux/amd64`, `linux/arm64`, and `linux/arm/v7`.)~~

^ Nevermind, making things multi-platform is too difficult right now. I'll still try to update the build to remove the outdated `rust-musl-builder` image, but the only supported platform will remain `linux/amd64`.