### PR TITLE
Improve persistence logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,6 +1067,7 @@ dependencies = [
  "operational-transform",
  "parking_lot",
  "pretty_env_logger",
+ "rand 0.8.3",
  "serde",
  "serde_json",
  "sqlx",

--- a/rustpad-server/Cargo.toml
+++ b/rustpad-server/Cargo.toml
@@ -14,13 +14,13 @@ log = "0.4.14"
 operational-transform = { version = "0.6.0", features = ["serde"] }
 parking_lot = "0.11.1"
 pretty_env_logger = "0.4.0"
+rand = "0.8.3"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 sqlx = { version = "0.5.9", features = ["runtime-tokio-rustls", "sqlite"] }
 tokio = { version = "1.6.1", features = ["full", "test-util"] }
 tokio-stream = "0.1.6"
 warp = "0.3.1"
-rand = "0.8"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/rustpad-server/Cargo.toml
+++ b/rustpad-server/Cargo.toml
@@ -20,6 +20,7 @@ sqlx = { version = "0.5.9", features = ["runtime-tokio-rustls", "sqlite"] }
 tokio = { version = "1.6.1", features = ["full", "test-util"] }
 tokio-stream = "0.1.6"
 warp = "0.3.1"
+rand = "0.8"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/rustpad-server/src/database.rs
+++ b/rustpad-server/src/database.rs
@@ -49,10 +49,13 @@ impl Database {
     pub async fn store(&self, document_id: &str, document: &PersistedDocument) -> Result<()> {
         let result = sqlx::query(
             r#"
-INSERT OR REPLACE INTO
+INSERT INTO
     document (id, text, language)
 VALUES
-    ($1, $2, $3)"#,
+    ($1, $2, $3)
+ON CONFLICT(id) DO UPDATE SET
+    text = excluded.text,
+    language = excluded.language"#,
         )
         .bind(document_id)
         .bind(&document.text)

--- a/rustpad-server/src/lib.rs
+++ b/rustpad-server/src/lib.rs
@@ -216,9 +216,7 @@ async fn persister(id: String, rustpad: Arc<Rustpad>, db: Database) {
     let mut last_revision = 0;
     while !rustpad.killed() {
         let interval = PERSIST_INTERVAL
-            + Duration::from_millis(
-                rand::thread_rng().gen_range(0..=PERSIST_INTERVAL_JITTER.as_millis() as u64),
-            );
+            + rand::thread_rng().gen_range(Duration::ZERO..=PERSIST_INTERVAL_JITTER);
         time::sleep(interval).await;
         let revision = rustpad.revision();
         if revision > last_revision {

--- a/rustpad-server/src/lib.rs
+++ b/rustpad-server/src/lib.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, SystemTime};
 
 use dashmap::DashMap;
 use log::{error, info};
+use rand::Rng;
 use serde::Serialize;
 use tokio::time::{self, Instant};
 use warp::{filters::BoxedFilter, ws::Ws, Filter, Rejection, Reply};
@@ -208,19 +209,25 @@ async fn cleaner(state: ServerState, expiry_days: u32) {
 }
 
 const PERSIST_INTERVAL: Duration = Duration::from_secs(3);
+const PERSIST_INTERVAL_JITTER: Duration = Duration::from_secs(1);
 
 /// Persists changed documents after a fixed time interval.
 async fn persister(id: String, rustpad: Arc<Rustpad>, db: Database) {
     let mut last_revision = 0;
     while !rustpad.killed() {
-        time::sleep(PERSIST_INTERVAL).await;
+        let interval = PERSIST_INTERVAL
+            + Duration::from_millis(
+                rand::thread_rng().gen_range(0..=PERSIST_INTERVAL_JITTER.as_millis() as u64),
+            );
+        time::sleep(interval).await;
         let revision = rustpad.revision();
         if revision > last_revision {
             info!("persisting revision {} for id = {}", revision, id);
             if let Err(e) = db.store(&id, &rustpad.snapshot()).await {
                 error!("when persisting document {}: {}", id, e);
+            } else {
+                last_revision = revision;
             }
-            last_revision = revision;
         }
     }
 }


### PR DESCRIPTION
- If the database persistence operation failed, do not update `last_revision` to allow it to retry.
- Add a jitter to `PERSIST_INTERVAL` to scatter DB access into a uniform pattern.
- Use `INSERT ... ON CONFLICT` instead of `INSERT OR REPLACE` (this avoids SQLite ROWID re-assignment).
