### PR TITLE
Fix --platform=amd64 syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@ COPY . .
 RUN cargo test --release
 RUN cargo build --release
 
-FROM amd64/rust:alpine AS wasm
+FROM --platform=amd64 rust:alpine AS wasm
 WORKDIR /home/rust/src
 RUN apk --no-cache add curl musl-dev
 RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 COPY . .
 RUN wasm-pack build --target web rustpad-wasm
 
-FROM amd64/node:lts-alpine AS frontend
+FROM --platform=amd64 node:lts-alpine AS frontend
 WORKDIR /usr/src/app
 COPY package.json package-lock.json ./
 COPY --from=wasm /home/rust/src/rustpad-wasm/pkg rustpad-wasm/pkg


### PR DESCRIPTION
Docker still requires amd64 to build these steps for some reason, but the syntax has changed in more recent versions. I don't know why or remember from 2 years ago. But here we are.