### PR TITLE
Make WebSocket URL relative to path on which RustPad itself is served

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,11 +36,9 @@ import Footer from "./Footer";
 import User from "./User";
 
 function getWsUri(id: string) {
-  return (
-    (window.location.origin.startsWith("https") ? "wss://" : "ws://") +
-    window.location.host +
-    `/api/socket/${id}`
-  );
+  let url = new URL(`api/socket/${id}`, window.location.href);
+  url.protocol = (url.protocol == "https:") ? "wss:" : "ws:";
+  return url.href;
 }
 
 function generateName() {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import topLevelAwait from "vite-plugin-top-level-await";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  base: "",
   build: {
     chunkSizeWarningLimit: 1000,
   },


### PR DESCRIPTION
The path stays the same in all currently supported scenarios, but this also allows serving the app from a subpath.