### PR TITLE
Responsive sidebar width and confirmation on "read code" button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,36 +1,13 @@
-import {
-  Box,
-  Button,
-  Container,
-  Flex,
-  HStack,
-  Heading,
-  Icon,
-  Input,
-  InputGroup,
-  InputRightElement,
-  Link,
-  Select,
-  Stack,
-  Switch,
-  Text,
-  useToast,
-} from "@chakra-ui/react";
+import { Box, Flex, HStack, Icon, Text, useToast } from "@chakra-ui/react";
 import Editor from "@monaco-editor/react";
 import { editor } from "monaco-editor/esm/vs/editor/editor.api";
 import { useEffect, useRef, useState } from "react";
-import {
-  VscChevronRight,
-  VscFolderOpened,
-  VscGist,
-  VscRepoPull,
-} from "react-icons/vsc";
+import { VscChevronRight, VscFolderOpened, VscGist } from "react-icons/vsc";
 import useLocalStorageState from "use-local-storage-state";
 
 import rustpadRaw from "../rustpad-server/src/rustpad.rs?raw";
-import ConnectionStatus from "./ConnectionStatus";
 import Footer from "./Footer";
-import User from "./User";
+import Sidebar from "./Sidebar";
 import animals from "./animals.json";
 import languages from "./languages.json";
 import Rustpad, { UserInfo } from "./rustpad";
@@ -109,7 +86,7 @@ function App() {
     }
   }, [connection, name, hue]);
 
-  function handleChangeLanguage(language: string) {
+  function handleLanguageChange(language: string) {
     setLanguage(language);
     if (rustpad.current?.setLanguage(language)) {
       toast({
@@ -130,17 +107,6 @@ function App() {
     }
   }
 
-  async function handleCopy() {
-    await navigator.clipboard.writeText(`${window.location.origin}/#${id}`);
-    toast({
-      title: "Copied!",
-      description: "Link copied to clipboard",
-      status: "success",
-      duration: 2000,
-      isClosable: true,
-    });
-  }
-
   function handleLoadSample() {
     if (editor?.getModel()) {
       const model = editor.getModel()!;
@@ -156,12 +122,12 @@ function App() {
       );
       editor.setPosition({ column: 0, lineNumber: 0 });
       if (language !== "rust") {
-        handleChangeLanguage("rust");
+        handleLanguageChange("rust");
       }
     }
   }
 
-  function handleDarkMode() {
+  function handleDarkModeChange() {
     setDarkMode(!darkMode);
   }
 
@@ -184,116 +150,20 @@ function App() {
         Rustpad
       </Box>
       <Flex flex="1 0" minH={0}>
-        <Container
-          w="xs"
-          bgColor={darkMode ? "#252526" : "#f3f3f3"}
-          overflowY="auto"
-          maxW="full"
-          lineHeight={1.4}
-          py={4}
-        >
-          <ConnectionStatus darkMode={darkMode} connection={connection} />
+        <Sidebar
+          documentId={id}
+          connection={connection}
+          darkMode={darkMode}
+          language={language}
+          currentUser={{ name, hue }}
+          users={users}
+          onDarkModeChange={handleDarkModeChange}
+          onLanguageChange={handleLanguageChange}
+          onLoadSample={handleLoadSample}
+          onChangeName={(name) => name.length > 0 && setName(name)}
+          onChangeColor={() => setHue(generateHue())}
+        />
 
-          <Flex justifyContent="space-between" mt={4} mb={1.5} w="full">
-            <Heading size="sm">Dark Mode</Heading>
-            <Switch isChecked={darkMode} onChange={handleDarkMode} />
-          </Flex>
-
-          <Heading mt={4} mb={1.5} size="sm">
-            Language
-          </Heading>
-          <Select
-            size="sm"
-            bgColor={darkMode ? "#3c3c3c" : "white"}
-            borderColor={darkMode ? "#3c3c3c" : "white"}
-            value={language}
-            onChange={(event) => handleChangeLanguage(event.target.value)}
-          >
-            {languages.map((lang) => (
-              <option key={lang} value={lang} style={{ color: "black" }}>
-                {lang}
-              </option>
-            ))}
-          </Select>
-
-          <Heading mt={4} mb={1.5} size="sm">
-            Share Link
-          </Heading>
-          <InputGroup size="sm">
-            <Input
-              readOnly
-              pr="3.5rem"
-              variant="outline"
-              bgColor={darkMode ? "#3c3c3c" : "white"}
-              borderColor={darkMode ? "#3c3c3c" : "white"}
-              value={`${window.location.origin}/#${id}`}
-            />
-            <InputRightElement width="3.5rem">
-              <Button
-                h="1.4rem"
-                size="xs"
-                onClick={handleCopy}
-                _hover={{ bg: darkMode ? "#575759" : "gray.200" }}
-                bgColor={darkMode ? "#575759" : "gray.200"}
-              >
-                Copy
-              </Button>
-            </InputRightElement>
-          </InputGroup>
-
-          <Heading mt={4} mb={1.5} size="sm">
-            Active Users
-          </Heading>
-          <Stack spacing={0} mb={1.5} fontSize="sm">
-            <User
-              info={{ name, hue }}
-              isMe
-              onChangeName={(name) => name.length > 0 && setName(name)}
-              onChangeColor={() => setHue(generateHue())}
-              darkMode={darkMode}
-            />
-            {Object.entries(users).map(([id, info]) => (
-              <User key={id} info={info} darkMode={darkMode} />
-            ))}
-          </Stack>
-
-          <Heading mt={4} mb={1.5} size="sm">
-            About
-          </Heading>
-          <Text fontSize="sm" mb={1.5}>
-            <strong>Rustpad</strong> is an open-source collaborative text editor
-            based on the <em>operational transformation</em> algorithm.
-          </Text>
-          <Text fontSize="sm" mb={1.5}>
-            Share a link to this pad with others, and they can edit from their
-            browser while seeing your changes in real time.
-          </Text>
-          <Text fontSize="sm" mb={1.5}>
-            Built using Rust and TypeScript. See the{" "}
-            <Link
-              color="blue.600"
-              fontWeight="semibold"
-              href="https://github.com/ekzhang/rustpad"
-              isExternal
-            >
-              GitHub repository
-            </Link>{" "}
-            for details.
-          </Text>
-
-          <Button
-            size="sm"
-            colorScheme={darkMode ? "whiteAlpha" : "blackAlpha"}
-            borderColor={darkMode ? "purple.400" : "purple.600"}
-            color={darkMode ? "purple.400" : "purple.600"}
-            variant="outline"
-            leftIcon={<VscRepoPull />}
-            mt={1}
-            onClick={handleLoadSample}
-          >
-            Read the code
-          </Button>
-        </Container>
         <Flex flex={1} minW={0} h="100%" direction="column" overflow="hidden">
           <HStack
             h={6}

--- a/src/ReadCodeConfirm.tsx
+++ b/src/ReadCodeConfirm.tsx
@@ -1,0 +1,51 @@
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  Button,
+} from "@chakra-ui/react";
+import { useRef } from "react";
+
+export type ReadCodeConfirmProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+};
+
+/** Dialog for the "read the code" button when it clears the editor. */
+function ReadCodeConfirm({ isOpen, onClose, onConfirm }: ReadCodeConfirmProps) {
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <AlertDialog
+      isOpen={isOpen}
+      leastDestructiveRef={cancelRef}
+      onClose={onClose}
+    >
+      <AlertDialogOverlay>
+        <AlertDialogContent>
+          <AlertDialogHeader>Clear editor</AlertDialogHeader>
+
+          <AlertDialogBody>
+            Opening Rustpad's source code will clear the existing shared
+            content. Is this okay?
+          </AlertDialogBody>
+
+          <AlertDialogFooter>
+            <Button ref={cancelRef} onClick={onClose}>
+              Cancel
+            </Button>
+            <Button colorScheme="red" onClick={onConfirm} ml={3}>
+              Clear
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialogOverlay>
+    </AlertDialog>
+  );
+}
+
+export default ReadCodeConfirm;

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -65,7 +65,8 @@ function Sidebar({
 
   return (
     <Container
-      w="xs"
+      w={{ base: "3xs", md: "2xs", lg: "xs" }}
+      display={{ base: "none", sm: "block" }}
       bgColor={darkMode ? "#252526" : "#f3f3f3"}
       overflowY="auto"
       maxW="full"

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -116,6 +116,7 @@ function Sidebar({
             onClick={handleCopy}
             _hover={{ bg: darkMode ? "#575759" : "gray.200" }}
             bgColor={darkMode ? "#575759" : "gray.200"}
+            color={darkMode ? "white" : "inherit"}
           >
             Copy
           </Button>

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -1,0 +1,180 @@
+import {
+  Button,
+  Container,
+  Flex,
+  Heading,
+  Input,
+  InputGroup,
+  InputRightElement,
+  Link,
+  Select,
+  Stack,
+  Switch,
+  Text,
+  useToast,
+} from "@chakra-ui/react";
+import { VscRepo } from "react-icons/vsc";
+
+import ConnectionStatus from "./ConnectionStatus";
+import User from "./User";
+import languages from "./languages.json";
+import type { UserInfo } from "./rustpad";
+
+export type SidebarProps = {
+  documentId: string;
+  connection: "connected" | "disconnected" | "desynchronized";
+  darkMode: boolean;
+  language: string;
+  currentUser: UserInfo;
+  users: Record<number, UserInfo>;
+  onDarkModeChange: () => void;
+  onLanguageChange: (language: string) => void;
+  onLoadSample: () => void;
+  onChangeName: (name: string) => void;
+  onChangeColor: () => void;
+};
+
+function Sidebar({
+  documentId,
+  connection,
+  darkMode,
+  language,
+  currentUser,
+  users,
+  onDarkModeChange,
+  onLanguageChange,
+  onLoadSample,
+  onChangeName,
+  onChangeColor,
+}: SidebarProps) {
+  const toast = useToast();
+
+  // For sharing the document by link to others.
+  const documentUrl = `${window.location.origin}/#${documentId}`;
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(documentUrl);
+    toast({
+      title: "Copied!",
+      description: "Link copied to clipboard",
+      status: "success",
+      duration: 2000,
+      isClosable: true,
+    });
+  }
+
+  return (
+    <Container
+      w="xs"
+      bgColor={darkMode ? "#252526" : "#f3f3f3"}
+      overflowY="auto"
+      maxW="full"
+      lineHeight={1.4}
+      py={4}
+    >
+      <ConnectionStatus darkMode={darkMode} connection={connection} />
+
+      <Flex justifyContent="space-between" mt={4} mb={1.5} w="full">
+        <Heading size="sm">Dark Mode</Heading>
+        <Switch isChecked={darkMode} onChange={onDarkModeChange} />
+      </Flex>
+
+      <Heading mt={4} mb={1.5} size="sm">
+        Language
+      </Heading>
+      <Select
+        size="sm"
+        bgColor={darkMode ? "#3c3c3c" : "white"}
+        borderColor={darkMode ? "#3c3c3c" : "white"}
+        value={language}
+        onChange={(event) => onLanguageChange(event.target.value)}
+      >
+        {languages.map((lang) => (
+          <option key={lang} value={lang} style={{ color: "black" }}>
+            {lang}
+          </option>
+        ))}
+      </Select>
+
+      <Heading mt={4} mb={1.5} size="sm">
+        Share Link
+      </Heading>
+      <InputGroup size="sm">
+        <Input
+          readOnly
+          pr="3.5rem"
+          variant="outline"
+          bgColor={darkMode ? "#3c3c3c" : "white"}
+          borderColor={darkMode ? "#3c3c3c" : "white"}
+          value={documentUrl}
+        />
+        <InputRightElement width="3.5rem">
+          <Button
+            h="1.4rem"
+            size="xs"
+            onClick={handleCopy}
+            _hover={{ bg: darkMode ? "#575759" : "gray.200" }}
+            bgColor={darkMode ? "#575759" : "gray.200"}
+          >
+            Copy
+          </Button>
+        </InputRightElement>
+      </InputGroup>
+
+      <Heading mt={4} mb={1.5} size="sm">
+        Active Users
+      </Heading>
+      <Stack spacing={0} mb={1.5} fontSize="sm">
+        <User
+          info={currentUser}
+          isMe
+          onChangeName={onChangeName}
+          onChangeColor={onChangeColor}
+          darkMode={darkMode}
+        />
+        {Object.entries(users).map(([id, info]) => (
+          <User key={id} info={info} darkMode={darkMode} />
+        ))}
+      </Stack>
+
+      <Heading mt={4} mb={1.5} size="sm">
+        About
+      </Heading>
+      <Text fontSize="sm" mb={1.5}>
+        <strong>Rustpad</strong> is an open-source collaborative text editor
+        based on the <em>operational transformation</em> algorithm.
+      </Text>
+      <Text fontSize="sm" mb={1.5}>
+        Share a link to this pad with others, and they can edit from their
+        browser while seeing your changes in real time.
+      </Text>
+      <Text fontSize="sm" mb={1.5}>
+        Built using Rust and TypeScript. See the{" "}
+        <Link
+          color="blue.600"
+          fontWeight="semibold"
+          href="https://github.com/ekzhang/rustpad"
+          isExternal
+        >
+          GitHub repository
+        </Link>{" "}
+        for details.
+      </Text>
+
+      <Button
+        size="sm"
+        colorScheme={darkMode ? "whiteAlpha" : "blackAlpha"}
+        borderColor={darkMode ? "purple.400" : "purple.600"}
+        color={darkMode ? "purple.400" : "purple.600"}
+        variant="outline"
+        leftIcon={<VscRepo />}
+        mt={1}
+        onClick={onLoadSample}
+      >
+        Read the code
+      </Button>
+    </Container>
+  );
+}
+
+export default Sidebar;

--- a/src/User.tsx
+++ b/src/User.tsx
@@ -24,8 +24,8 @@ import { UserInfo } from "./rustpad";
 type UserProps = {
   info: UserInfo;
   isMe?: boolean;
-  onChangeName?: (name: string) => unknown;
-  onChangeColor?: () => unknown;
+  onChangeName?: (name: string) => void;
+  onChangeColor?: () => void;
   darkMode: boolean;
 };
 

--- a/src/rustpad.ts
+++ b/src/rustpad.ts
@@ -10,11 +10,11 @@ import { OpSeq } from "rustpad-wasm";
 export type RustpadOptions = {
   readonly uri: string;
   readonly editor: editor.IStandaloneCodeEditor;
-  readonly onConnected?: () => unknown;
-  readonly onDisconnected?: () => unknown;
-  readonly onDesynchronized?: () => unknown;
-  readonly onChangeLanguage?: (language: string) => unknown;
-  readonly onChangeUsers?: (users: Record<number, UserInfo>) => unknown;
+  readonly onConnected?: () => void;
+  readonly onDisconnected?: () => void;
+  readonly onDesynchronized?: () => void;
+  readonly onChangeLanguage?: (language: string) => void;
+  readonly onChangeUsers?: (users: Record<number, UserInfo>) => void;
   readonly reconnectInterval?: number;
 };
 


### PR DESCRIPTION
Resolves #61 and adds a confirmation popup when clicking the "Read the code" button when there are already 10 or more lines of code in the editor to avoid accidental clearing.


https://github.com/user-attachments/assets/d39df661-a354-4857-b657-52ffe7ffd6b9

<img width="554" alt="image" src="https://github.com/user-attachments/assets/9537fe73-578c-47df-9256-676aa1e728f9" />
