### PR TITLE
Adjust clear editor confirmation dialog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,8 +115,8 @@ function App() {
       const model = editor.getModel()!;
       const range = model.getFullModelRange();
 
-      // If there are at least 10 lines of code, ask for confirmation.
-      if (range.endLineNumber >= 10 && !confirmed) {
+      // If editor contains more than the initial line of code, ask for confirmation.
+      if (range.endLineNumber > 1 && !confirmed) {
         setReadCodeConfirmOpen(true);
         return;
       }

--- a/src/ReadCodeConfirm.tsx
+++ b/src/ReadCodeConfirm.tsx
@@ -27,10 +27,10 @@ function ReadCodeConfirm({ isOpen, onClose, onConfirm }: ReadCodeConfirmProps) {
     >
       <AlertDialogOverlay>
         <AlertDialogContent>
-          <AlertDialogHeader>Clear editor</AlertDialogHeader>
+          <AlertDialogHeader>Replace editor content?</AlertDialogHeader>
 
           <AlertDialogBody>
-            Opening Rustpad's source code will clear the existing shared
+            Opening Rustpad's source code will replace the existing shared
             content. Is this okay?
           </AlertDialogBody>
 
@@ -39,7 +39,7 @@ function ReadCodeConfirm({ isOpen, onClose, onConfirm }: ReadCodeConfirmProps) {
               Cancel
             </Button>
             <Button colorScheme="red" onClick={onConfirm} ml={3}>
-              Clear
+              Replace
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>


### PR DESCRIPTION
Clicking on "read the code" will replace the entire editor and can be a very destructive action, especially for users unaware of `Ctrl + Z`. The current confirmation dialog has a threshold of 10 lines of code, meaning smaller documents can still be replaced accidentally.

This PR reduces the threshold to two lines (as one line will always exist in the editor, even when it's empty).
I also rephrased the dialog to use the word replace instead of clear to make the resulting action clearer. This should improve user experience and prevent accidental loss of data for smaller documents.

It's essentially a follow-up to my comment [here](https://github.com/ekzhang/rustpad/issues/91#issuecomment-2833520705). Let me know what you think.